### PR TITLE
Fix(Chopper): Prevent incorrect sequence position synchronization

### DIFF
--- a/AmenBreakChopper/Source/PluginProcessor.cpp
+++ b/AmenBreakChopper/Source/PluginProcessor.cpp
@@ -426,6 +426,7 @@ void AmenBreakChopperAudioProcessor::processBlock (juce::AudioBuffer<float>& buf
         {
             mNoteSequencePosition = mSequencePosition; // Sync Note-Seq to Main-Seq
             mValueTreeState.getParameter("delayTime")->setValueNotifyingHost(0.0f); // Reset DelayTime
+            mNewNoteReceived = false;
             mSequenceResetQueued = false;
         }
 


### PR DESCRIPTION
Resolves a race condition in the sequencer logic.

Previously, if a sequence reset event (`mSequenceResetQueued`) and a new note event (`mNewNoteReceived`) occurred in the same processing block, the `noteSequencePosition` would be correctly synced with `sequencePosition` and `delayTime` would be reset to 0.

However, the `mNewNoteReceived` flag was not cleared, causing the `delayTime` to be immediately recalculated to a non-zero value in the same tick, leading to an inconsistent state where the sequence positions were synchronized but the delay time was not zero.

This fix adds `mNewNoteReceived = false;` to the sequence reset logic, ensuring that the new note event is consumed and does not overwrite the correctly reset `delayTime`.